### PR TITLE
Add PyBrxCvDbLabelStyleComponent

### DIFF
--- a/PyRxCore/PyBrxCv.cpp
+++ b/PyRxCore/PyBrxCv.cpp
@@ -117,6 +117,7 @@ BOOST_PYTHON_MODULE(PyBrxCv)
 #if !defined(_BRXTARGET240)
     makePyBrxCvDbStyleWrapper();
     makeBrxCvDbStylePartDisplaySettingsWrapper();
+    makeBrxCvDbLabelStyleComponentWrapper();
 #endif
 
     enum_<PyBrxCvDbStyleManager::EStyleManagerType>("StyleManagerType")
@@ -549,6 +550,29 @@ BOOST_PYTHON_MODULE(PyBrxCv)
         .value("eOrientationReferenceView", BrxCvDbStyle::OrientationRef::eOrientationReferenceView)
         .value("eOrientationReferenceWCS", BrxCvDbStyle::OrientationRef::eOrientationReferenceWCS)
         .value("eOrientationReferenceStartLeaderAtMarker", BrxCvDbStyle::OrientationRef::eOrientationReferenceStartLeaderAtMarker)
+        .export_values()
+        ;
+#endif
+
+#if !defined(_BRXTARGET240)
+    enum_<BrxCvDbLabelStyleComponent::LabelAnchor>("LabelAnchor")
+        .value("eLabelAnchors", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchors)
+        .value("eLabelAnchorStart", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorStart)
+        .value("eLabelAnchorMiddle", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorMiddle)
+        .value("eLabelAnchorEnd", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorEnd)
+        .value("eLabelAnchorTopLeft", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorTopLeft)
+        .value("eLabelAnchorTopCenter", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorTopCenter)
+        .value("eLabelAnchorTopRight", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorTopRight)
+        .value("eLabelAnchorMiddleLeft", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorMiddleLeft)
+        .value("eLabelAnchorMiddleCenter", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorMiddleCenter)
+        .value("eLabelAnchorMiddleRight", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorMiddleRight)
+        .value("eLabelAnchorBottomLeft", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorBottomLeft)
+        .value("eLabelAnchorBottomCenter", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorBottomCenter)
+        .value("eLabelAnchorBottomRight", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorBottomRight)
+        .value("eLabelAnchorInsertionPoint", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorInsertionPoint)
+        .value("eLabelAnchorCurveCenter", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorCurveCenter)
+        .value("eLabelAnchorCurvePI", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorCurvePI)
+        .value("eLabelAnchorFeatureLocation", BrxCvDbLabelStyleComponent::LabelAnchor::eLabelAnchorFeatureLocation)
         .export_values()
         ;
 #endif

--- a/PyRxCore/PyBrxCvDbLabel.cpp
+++ b/PyRxCore/PyBrxCvDbLabel.cpp
@@ -131,7 +131,6 @@ BrxCvDbStylePartDisplaySettings* PyBrxCvDbStylePartDisplaySettings::impObj(const
 //PyBrxCvDbStyle
 void makePyBrxCvDbStyleWrapper()
 {
-
     PyDocString DS("CvDbStyle");
     class_<PyBrxCvDbStyle, bases<PyBrxCvDbObject>>("CvDbStyle", boost::python::no_init)
         .def(init<const PyDbObjectId&>())
@@ -226,6 +225,77 @@ BrxCvDbStyle* PyBrxCvDbStyle::impObj(const std::source_location& src /*= std::so
         throw PyNullObject(src);
     }
     return static_cast<BrxCvDbStyle*>(m_pyImp.get());
+}
+
+//-----------------------------------------------------------------------------------
+//PyBrxCvDbStylePartDisplaySettings
+void makeBrxCvDbLabelStyleComponentWrapper()
+{
+    PyDocString DS("CvDbLabelStyleComponent");
+    class_<PyBrxCvDbLabelStyleComponent, bases<PyBrxCvDbSubObject>>("CvDbLabelStyleComponent", boost::python::no_init)
+        .def("displaySetting", &PyBrxCvDbLabelStyleComponent::isVisible, DS.ARGS())
+        .def("setVisible", &PyBrxCvDbLabelStyleComponent::setVisible, DS.ARGS({ "val: bool" }))
+        .def("color", &PyBrxCvDbLabelStyleComponent::color, DS.ARGS())
+        .def("setColor", &PyBrxCvDbLabelStyleComponent::setColor, DS.ARGS({ "clr: PyDb.Color" }))
+        .def("anchorIndex", &PyBrxCvDbLabelStyleComponent::anchorIndex, DS.ARGS())
+        .def("setAnchorIndex", &PyBrxCvDbLabelStyleComponent::setAnchorIndex, DS.ARGS({ "val : int" }))
+        .def("anchorPoint", &PyBrxCvDbLabelStyleComponent::anchorPoint, DS.ARGS({ "val : int|str" }))
+        .def("setAnchorPoint", &PyBrxCvDbLabelStyleComponent::setAnchorPoint, DS.ARGS({ "val : int|str" }))
+        ;
+}
+
+PyBrxCvDbLabelStyleComponent::PyBrxCvDbLabelStyleComponent(BrxCvDbLabelStyleComponent* ptr, bool autoDelete)
+    : PyBrxCvDbSubObject(ptr, autoDelete)
+{
+}
+
+bool PyBrxCvDbLabelStyleComponent::isVisible() const
+{
+    return impObj()->isVisible();
+}
+
+void PyBrxCvDbLabelStyleComponent::setVisible(bool isVisible)
+{
+    PyThrowBadEs(impObj()->setVisible(isVisible));
+}
+
+AcCmColor PyBrxCvDbLabelStyleComponent::color() const
+{
+    return impObj()->color();
+}
+
+void PyBrxCvDbLabelStyleComponent::setColor(const AcCmColor& value)
+{
+    PyThrowBadEs(impObj()->setColor(value));
+}
+
+Adesk::UInt32 PyBrxCvDbLabelStyleComponent::anchorIndex() const
+{
+    return impObj()->anchorIndex();
+}
+
+void PyBrxCvDbLabelStyleComponent::setAnchorIndex(Adesk::UInt32 index)
+{
+    PyThrowBadEs(impObj()->setAnchorIndex(index));
+}
+
+BrxCvDbLabelStyleComponent::LabelAnchor PyBrxCvDbLabelStyleComponent::anchorPoint() const
+{
+    //SSC
+    return impObj()->anchorPoint();
+}
+
+void PyBrxCvDbLabelStyleComponent::setAnchorPoint(LabelAnchor anchor)
+{
+    PyThrowBadEs(impObj()->setAnchorPoint(anchor));
+}
+
+BrxCvDbLabelStyleComponent* PyBrxCvDbLabelStyleComponent::impObj(const std::source_location& src /*= std::source_location::current()*/) const
+{
+    if (m_pyImp == nullptr) [[unlikely]] {
+        throw PyNullObject(src);
+    }
+    return static_cast<BrxCvDbLabelStyleComponent*>(m_pyImp.get());
 }
 
 #endif

--- a/PyRxCore/PyBrxCvDbLabel.h
+++ b/PyRxCore/PyBrxCvDbLabel.h
@@ -74,6 +74,36 @@ public:
     inline BrxCvDbStyle* impObj(const std::source_location& src = std::source_location::current()) const;
 };
 
+//-----------------------------------------------------------------------------------
+//PyBrxCvDbStylePartDisplaySettings
+void makeBrxCvDbLabelStyleComponentWrapper();
+
+class PyBrxCvDbLabelStyleComponent : public PyBrxCvDbSubObject
+{
+    using LabelAnchor = BrxCvDbLabelStyleComponent::LabelAnchor;
+public:
+    PyBrxCvDbLabelStyleComponent(BrxCvDbLabelStyleComponent* ptr, bool autoDelete);
+    virtual ~PyBrxCvDbLabelStyleComponent() override = default;
+
+    bool            isVisible() const;
+    void            setVisible(bool isVisible);
+    AcCmColor       color() const;
+    void            setColor(const AcCmColor& value);
+    Adesk::UInt32   anchorIndex() const;
+    void            setAnchorIndex(Adesk::UInt32 index);
+    LabelAnchor     anchorPoint() const;
+    void            setAnchorPoint(LabelAnchor anchor);
+    //SSC
+    //using BrxCvDbLabelStyleComponentPtr = AcSharedPtr<BrxCvDbLabelStyleComponent>;
+    //using BrxCvDbLabelStyleComponentPtrArray = AcArray<BrxCvDbLabelStyleComponentPtr>;
+
+public:
+    inline BrxCvDbLabelStyleComponent* impObj(const std::source_location& src = std::source_location::current()) const;
+public:
+    //SSC
+    std::shared_ptr<BrxCvDbLabelStyleComponent> m_pyImp;
+};
+
 #endif
 
 #endif//BRXAPP


### PR DESCRIPTION
Please check entries below `//SSC`

1. Missing interpretation for `BrxCvDbLabelStyleComponent.h`
```
using BrxCvDbLabelStyleComponentPtr = AcSharedPtr<BrxCvDbLabelStyleComponent>;
using BrxCvDbLabelStyleComponentPtrArray = AcArray<BrxCvDbLabelStyleComponentPtr>; 
```

2. Interpreted `BrxCvDbLabelStyleComponent.h`
```
protected:    
    BrxCvDbLabelStyleComponent();
```
as
```
public:
    std::shared_ptr<BrxCvDbLabelStyleComponent> m_pyImp;
```

3. Member type correctly defined?
```
BrxCvDbLabelStyleComponent::LabelAnchor PyBrxCvDbLabelStyleComponent::anchorPoint() const
{
    //SSC
    return impObj()->anchorPoint();
}
```