### PR TITLE
test runner - add pytest and pyinit args

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -44,3 +44,21 @@ To enable debug mode:
 ```bash
 run_tests --debug
 ```
+
+Passing pytest cmd options:
+
+```bash
+run_tests <other_args> --pytest <only_pytest_marks>
+```
+
+Passing embedded python config flags:
+
+```bash
+run_tests --pyinit 0xFFFFFFFF
+```
+
+Complex example:
+
+```bash
+run_tests --pyinit 0xFFFFFFFF --hosts acad zcad --debug --known-failures --pytest --co
+```

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as c
 import dataclasses
 import pickle
 import typing as t
@@ -15,6 +16,7 @@ if t.TYPE_CHECKING:
 class TestConfig:
     slow_tests: bool = True
     known_failures: bool = True
+    pytest_args: c.Sequence[str] | None = None
 
     def dump(self, file: _t.StrPath) -> None:
         with open(file, "wb") as f:

--- a/tests/host_runner.py
+++ b/tests/host_runner.py
@@ -21,20 +21,24 @@ def run_tests(cfg: TestConfig):
     with open(log_filename, "w", encoding="utf-8") as log_file:
         with redirect_stdout(log_file), redirect_stderr(log_file):
             pytest_args = [*STANDARD_PYTEST_ARGS]
-            not_markers = []
-            if cfg.known_failures is False:
-                not_markers.extend(_get_known_failures_markers())
-            if cfg.slow_tests is False:
-                not_markers.append("slow")
-            if not_markers:
-                markers_arg = "not " + " and not ".join(not_markers)
-                pytest_args.extend(("-m", markers_arg))
+            if cfg.pytest_args:
+                pytest_args.extend(cfg.pytest_args)
+            if "-m" not in pytest_args:
+                not_markers = []
+                if cfg.known_failures is False:
+                    not_markers.extend(_get_known_failures_markers())
+                if cfg.slow_tests is False:
+                    not_markers.append("slow")
+                if not_markers:
+                    markers_arg = "not " + " and not ".join(not_markers)
+                    pytest_args.extend(("-m", markers_arg))
             pytest.main(pytest_args)
 
 
 @Ap.Command("RUN_TESTS")
 def run_tests_cmd():
     try:
+        # config
         status, cfg_file = Ed.Editor.getString("\nconfig file: ")
         if not status == Ed.PromptStatus.eOk:
             raise RuntimeError(str(status))


### PR DESCRIPTION
|                  |           |
| ------------ | -------
| Issue          | #172
| Discussion | #160 
| Thread       | https://github.com/CEXT-Dan/PyRx/discussions/160#discussioncomment-11811740



Passing pytest cmd options:

```bash
run_tests <other_args> --pytest <only_pytest_marks>
```

Passing embedded python config flags:

```bash
run_tests --pyinit 0xFFFFFFFF
```

Complex example:

```bash
run_tests --pyinit 0xFFFFFFFF --hosts acad zcad --debug --known-failures --pytest --co
```
