### PR TITLE
add command decorator

### DIFF
--- a/PySamples/testCmdFlags.py
+++ b/PySamples/testCmdFlags.py
@@ -1,5 +1,5 @@
 import traceback
-from pyrx_imp import Rx, Ge, Gi, Db, Ap, Ed
+from pyrx import Ap, command
 
 # MODAL           
 # TRANSPARENT     
@@ -80,3 +80,22 @@ def foohar():
     except Exception as err:
         traceback.print_exception(err)
 
+
+@command
+def pycmd1(a=1):
+    print(a)
+
+
+@command
+def pyraise():
+    raise RuntimeError
+
+
+@command(name="pycmd3")
+def pycmd2():
+    print("PYCMD3")
+
+
+@command(flags=Ap.CmdFlags.SESSION)
+def pysession():
+    print("SESSION")

--- a/pyrx/__init__.py
+++ b/pyrx/__init__.py
@@ -46,5 +46,6 @@ if TYPE_CHECKING:
     if importlib.util.find_spec("PyBrx") is not None:
         from . import PyBrx as Brx  # noqa: F811  # type: ignore
 
+from .commands import command
 
-__all__ = ("Ap", "Br", "Db", "Ed", "Ge", "Gi", "Gs", "Pl", "Rx", "Sm", "Ax")
+__all__ = ("Ap", "Br", "Db", "Ed", "Ge", "Gi", "Gs", "Pl", "Rx", "Sm", "Ax", "command",)

--- a/pyrx/commands.py
+++ b/pyrx/commands.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import inspect
+import traceback
+import typing as t
+from functools import wraps
+
+from pyrx import Ap
+
+if t.TYPE_CHECKING:
+    import types
+
+
+def command(
+    func: types.FunctionType | None = None,
+    *,
+    name: str | None = None,
+    flags: Ap.CmdFlags | None = None,
+):
+    """
+    A decorator to register a function as a command in the application.
+
+    The decorated function must have all parameters with default values.
+
+    Parameters:
+        func: The function to be registered as a command.
+        name: The name of the command. If None, the function's name is used.
+        flags: The flags for the command. If None, Ap.CmdFlags.MODAL is used.
+
+    Raises:
+        TypeError: If the function has parameters without default values.
+
+    Examples::
+
+        @command
+        def my_command():
+            print("Command executed")
+
+        @command(name="CUSTOM_COMMAND")
+        def another_command():
+            print("Another command executed")
+
+        @command(flags=Ap.CmdFlags.SESSION)
+        def session_command():
+            print("Session command executed")
+    """
+
+    def decorator(func: types.FunctionType):
+        for param_name, param in inspect.signature(func).parameters.items():
+            if param.default is inspect.Parameter.empty:
+                raise TypeError(
+                    f"Command function {func.__name__!r} has a non-default parameter {param_name!r}"
+                )
+
+        nonlocal name, flags
+        if name is None:
+            name = func.__name__.lstrip("_")
+        if flags is None:
+            flags = Ap.CmdFlags.MODAL
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            caller = inspect.currentframe().f_back
+            if caller is not None:  # standard function call
+                return func(*args, **kwargs)
+            else:  # called as a command
+                try:
+                    func(*args, **kwargs)
+                except Exception as e:
+                    traceback.print_exception(e.with_traceback(e.__traceback__.tb_next))
+
+        Ap.Application.regCommand(
+            func.__globals__["__file__"], func.__module__, name, wrapper, flags
+        )
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    else:
+        return decorator

--- a/tests/test_commands/_test_commands.py
+++ b/tests/test_commands/_test_commands.py
@@ -1,0 +1,11 @@
+from pyrx.commands import command
+
+
+@command
+def command_1(a=1):
+    print(a)
+
+
+@command(name="cmd_2")
+def command_2():
+    raise RuntimeError("Test cmd 2")

--- a/tests/test_commands/test_commands.py
+++ b/tests/test_commands/test_commands.py
@@ -1,0 +1,150 @@
+import re
+import subprocess
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from pyrx import Ap, Ax, Ed
+from pyrx.commands import command
+
+BASE_DIR = Path(__file__).parent
+
+
+class _CommandRow(t.NamedTuple):
+    name: str
+    local_name: str
+    flags: Ap.CmdFlags
+
+
+# region: test command decorator
+
+
+def get_registered_commands():
+    key = f"PY_{__name__.upper()}"
+    all_commands = Ed.Core.getCommands()
+    if key not in all_commands:
+        return
+    for cmd in all_commands[key]:
+        yield _CommandRow(*cmd)
+
+
+before_registered_commands = set(get_registered_commands())
+
+
+@command
+def cmd_test_1():
+    return 1
+
+
+@command(name="COMMAND_TEST_2")
+def cmd_test_2():
+    return 2
+
+
+@command(flags=Ap.CmdFlags.SESSION)
+def cmd_test_3():
+    return 3
+
+
+after_registered_commands = set(get_registered_commands())
+diff_registered_commands = after_registered_commands - before_registered_commands
+diff_registered_command_names = {cmd.name for cmd in diff_registered_commands}
+
+
+class Test_command_decorator:
+    def test_without_brackets(self):
+        assert "CMD_TEST_1" in diff_registered_command_names
+        for cmd in diff_registered_commands:
+            if cmd.name == "CMD_TEST_1":
+                assert cmd.flags == Ap.CmdFlags.MODAL
+                break
+        else:
+            raise RuntimeError("Command not found")
+
+    def test_with_brackets(self):
+        assert "COMMAND_TEST_2" in diff_registered_command_names
+        for cmd in diff_registered_commands:
+            if cmd.name == "COMMAND_TEST_2":
+                assert cmd.flags == Ap.CmdFlags.MODAL
+                break
+        else:
+            raise RuntimeError("Command not found")
+
+    def test_with_flags(self):
+        assert "CMD_TEST_3" in diff_registered_command_names
+        for cmd in diff_registered_commands:
+            if cmd.name == "CMD_TEST_3":
+                assert cmd.flags == Ap.CmdFlags.SESSION
+                break
+        else:
+            raise RuntimeError("Command not found")
+
+    def test_non_default_params_raise_TypeError(self):
+        with pytest.raises(
+            TypeError, match="Command function 'test_1' has a non-default parameter 'param_1'"
+        ):
+
+            @command
+            def test_1(param_1, param_2=1):
+                pass
+
+    def test_func_called_directly(self):
+        @command
+        def test_2(a=1, b=2):
+            return a + b
+
+        res = test_2(3, 4)
+        assert res == 7
+
+        @command(name="test_3")
+        def test_2():
+            raise RuntimeError("Test 123")
+
+        with pytest.raises(RuntimeError, match="Test 123"):
+            test_2()
+
+    @pytest.mark.slow
+    def test_func_called_as_command(self, tmp_path: Path):
+        host_exe = Ax.AcadApplication().fullName()
+        pyrx_module_path = (
+            Path(Ap.Application.getPyRxModulePath()) / Ap.Application.getPyRxModuleName()
+        )
+        python_module_path = BASE_DIR / "_test_commands.py"
+        test_res_path = tmp_path / "test_res.txt"
+        scr_content = (
+            f'(adspyload "{python_module_path.as_posix()}")\n'
+            # redirect STDOUT/STDERR
+            "pycmdprompt\n"
+            "import sys\n"
+            f"sys.stdout = sys.stderr = open({test_res_path.as_posix()!r}, 'w', encoding='utf-8')\n"
+            "quit\n"  # quit pycmdprompt
+            "COMMAND_1\n"
+            "CMD_2\n"
+            "pycmdprompt\n"
+            "sys.stdout.close()\n"
+            "quit\n"  # quit pycmdprompt
+            "_quit\n_yes\n"  # quit host
+        )
+        scr_file = tmp_path / "test.scr"
+        scr_file.write_text(scr_content, encoding="ansi")
+        process = subprocess.Popen(
+            args=[host_exe, "/ld", str(pyrx_module_path), "/b", str(scr_file)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        res = None
+        TIMEOUT = 50
+        try:
+            process.wait(TIMEOUT)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            raise
+        res = test_res_path.read_text("utf-8")
+
+        expected_patt = r"1\nTraceback \(most recent call last\):.*RuntimeError: Test cmd 2.*"
+        assert re.match(expected_patt, res, re.DOTALL) is not None
+
+
+# endregion: test command decorator


### PR DESCRIPTION
#166 

this:

```py
from pyrx import Ap

@Ap.Command()
def foobar():
    try:
        print("foobar")
    except Exception as err:
        traceback.print_exception(err)
```

is the same as this:

```py
from pyrx import command

@command
def foobar():
    print("foobar")
```

the decorator is responsible for catching and displaying the exception