### PR TITLE
add reload utils

### DIFF
--- a/pyrx/__init__.py
+++ b/pyrx/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "2.2.2"
 
-import warnings
 import importlib.util
+import warnings
 from typing import TYPE_CHECKING
 
 try:
@@ -16,12 +16,13 @@ try:
     import PySm as Sm  # isort: skip  # type: ignore
     import PyBr as Br  # isort: skip  # type: ignore
     import PyAx as Ax  # isort: skip  # type: ignore
+
     if importlib.util.find_spec("PyBrxCv") is not None:
-        import PyBrxCv as Cv # isort: skip  # type: ignore
+        import PyBrxCv as Cv  # isort: skip  # type: ignore
     if importlib.util.find_spec("PyBrxBim") is not None:
-        import PyBrxBim as Bim # isort: skip  # type: ignore
+        import PyBrxBim as Bim  # isort: skip  # type: ignore
     if importlib.util.find_spec("PyBrx") is not None:
-        import PyBrx as Brx # isort: skip  # type: ignore
+        import PyBrx as Brx  # isort: skip  # type: ignore
 
 except ModuleNotFoundError:
     warnings.warn("PyRx modules are not available, they must be invoked from a CAD application.")
@@ -29,6 +30,7 @@ except ModuleNotFoundError:
 
 if TYPE_CHECKING:
     from . import PyAp as Ap  # noqa: F811  # type: ignore
+    from . import PyAx as Ax  # noqa: F811  # type: ignore
     from . import PyBr as Br  # noqa: F811  # type: ignore
     from . import PyDb as Db  # noqa: F811  # type: ignore
     from . import PyEd as Ed  # noqa: F811  # type: ignore
@@ -38,7 +40,7 @@ if TYPE_CHECKING:
     from . import PyPl as Pl  # noqa: F811  # type: ignore
     from . import PyRx as Rx  # noqa: F811  # type: ignore
     from . import PySm as Sm  # noqa: F811  # type: ignore
-    from . import PyAx as Ax  # noqa: F811  # type: ignore
+
     if importlib.util.find_spec("PyBrxCv") is not None:
         from . import PyBrxCv as Cv  # noqa: F811  # type: ignore
     if importlib.util.find_spec("PyBrxBim") is not None:
@@ -47,5 +49,6 @@ if TYPE_CHECKING:
         from . import PyBrx as Brx  # noqa: F811  # type: ignore
 
 from .commands import command
+from .utils.reload import reload
 
-__all__ = ("Ap", "Br", "Db", "Ed", "Ge", "Gi", "Gs", "Pl", "Rx", "Sm", "Ax", "command",)
+__all__ = ("Ap", "Br", "Db", "Ed", "Ge", "Gi", "Gs", "Pl", "Rx", "Sm", "Ax", "command", "reload")

--- a/pyrx/utils/reload.py
+++ b/pyrx/utils/reload.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import collections.abc as c
+import importlib
+import inspect
+import sys
+from contextlib import suppress
+
+
+class Reloader:
+    """
+    A class that manages module reloading.
+
+    Examples::
+
+        from pyrx.utils.reload import Reloader
+        import my_package.my_module
+        import my_module_2
+
+        def on_reload():
+            print("Reloaded")
+
+        reloader = Reloader("my_package", "my_module_2", func=on_reload)
+        reloader.register()
+    """
+
+    def __init__(self, *module_names: str, func: c.Callable[[], None] | None = None) -> None:
+        self._module_names_to_reload = module_names
+        self._reload_func = func
+
+    @property
+    def modules_to_reload(self):
+        chunks_list = tuple(name.split(".") for name in self._module_names_to_reload)
+        count_list = tuple(len(c) for c in chunks_list)
+        for name in sys.modules:
+            module_chunks = name.split(".")
+            for chunks, count in zip(chunks_list, count_list):
+                if module_chunks[:count] == chunks:
+                    yield name
+                    break
+
+    def reload_modules(self):
+        to_reload = set(self.modules_to_reload)
+        for name in to_reload:
+            sys.modules.pop(name)
+        for name in to_reload:
+            with suppress(ModuleNotFoundError):
+                importlib.import_module(name)
+
+    def reload(self) -> None:
+        if self._module_names_to_reload:
+            self.reload_modules()
+        if self._reload_func is not None:
+            self._reload_func()
+
+    def register(self, context=1):
+        caller_frame = inspect.stack()[context].frame
+        caller_frame.f_globals["OnPyReload"] = self.reload
+
+
+def reload(*module_names: str) -> None:
+    """
+    Register a function that reloads the specified modules/packages when
+    calling the command ``PYRELOAD`` / ``(adspyreload ...)`` or the
+    ``Ap.Application.reloadPythonModule`` method. Nested
+    modules/packages are also reloaded.
+
+    Examples::
+
+        from pyrx import reload
+        import my_package.my_module
+        import my_module_2
+
+        reload("my_package", "my_module_2")
+        # ...
+    """
+    reloader = Reloader(*module_names)
+    reloader.register(context=2)

--- a/tests/test_utils/test_reload.py
+++ b/tests/test_utils/test_reload.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager, suppress
+from pathlib import Path
+
+import pytest
+
+from pyrx import Ap, Ax, Ed
+from pyrx.utils.reload import Reloader
+
+BASE_DIR = Path(__file__).parent
+PACKAGE = "tests.test_utils"
+
+
+@contextmanager
+def create_temp_module(name: str, is_package=False):
+    try:
+        _paths: list[Path] = []
+        abs_module_name = f"{PACKAGE}.{name}"
+        assert abs_module_name not in sys.modules
+        name_chunks = name.split(".")
+        if is_package:
+            package_it = iter(name_chunks)
+        else:
+            package_it = iter(name_chunks[:-1])
+        package_path = BASE_DIR
+        while True:
+            package = next(package_it, None)
+            if package is None:
+                break
+            package_path = package_path / package
+            if not package_path.exists():
+                package_path.mkdir()
+                _paths.append(package_path)
+            package_init_path = package_path / "__init__.py"
+            if not package_init_path.exists():
+                package_init_path.touch()
+                _paths.append(package_init_path)
+        if not is_package:
+            module_path = package_path / f"{name_chunks[-1]}.py"
+            if not module_path.exists():
+                module_path.touch()
+                _paths.append(module_path)
+            else:
+                module_path.write_text("", encoding="utf-8")
+        yield abs_module_name, module_path
+    finally:
+        for path in reversed(_paths):
+            with suppress(OSError):
+                if path.is_file():
+                    path.unlink()
+                else:
+                    pycache_path = path / "__pycache__"
+                    if pycache_path.exists():
+                        shutil.rmtree(pycache_path)
+                    path.rmdir()
+
+
+class Test_Reload:
+    def test_reload(self):
+        reloader = Reloader(f"{PACKAGE}.package1", f"{PACKAGE}.package2")
+        with create_temp_module("package2.module1") as (m21_name, m21_path):
+            with create_temp_module("package1.module1.module2") as (m112_name, m112_path):
+                with create_temp_module("package1.module2") as (m12_name, m12_path):
+                    with create_temp_module("package2.module2") as (m22_name, m22_path):
+                        m112 = importlib.import_module(m112_name)
+                        m12 = importlib.import_module(m12_name)
+                        m21 = importlib.import_module(m21_name)
+                        m22 = importlib.import_module(m22_name)
+                        to_reload = set(reloader.modules_to_reload)
+                        assert len(to_reload) == 7
+                        assert m112_name in to_reload
+                        assert m21_name in to_reload
+                        assert m12_name in to_reload
+                        assert m22_name in to_reload
+                        modules = set(sys.modules.keys())
+                        modules_count = len(modules)
+                        assert getattr(m112, "ATTR", None) is None
+                        m112_path.write_text("ATTR = 1\n", encoding="utf-8")
+                        reloader.reload_modules()
+                        m112 = importlib.import_module(m112_name)
+                        assert m112.ATTR == 1
+                        assert not modules.symmetric_difference(set(sys.modules.keys()))
+                    reloader.reload_modules()
+                    modules_1 = set(sys.modules.keys())
+                    assert modules_count - len(modules_1) == 1, str(modules.difference(modules_1))
+                reloader.reload_modules()
+                modules_2 = set(sys.modules.keys())
+                assert modules_count - len(modules_2) == 2, str(modules.difference(modules_2))
+            reloader.reload_modules()
+            modules_3 = set(sys.modules.keys())
+            assert modules_count - len(modules_3) == 5, str(modules.difference(modules_3))
+        reloader.reload_modules()
+        modules_4 = set(sys.modules.keys())
+        assert modules_count - len(modules_4) == 7, str(modules.difference(modules_4))
+
+    def test_register(self, capsys: pytest.CaptureFixture[str]):
+        with create_temp_module("test_register_module_1") as (m1_name, m1_path):
+            assert Ed.Core.setVar("USERS1", "FAIL") is True
+            module_src = (
+                "from pyrx.utils.reload import Reloader\n"
+                "Reloader(func=lambda: print('{msg}')).register()\n"
+            )
+            m1_path.write_text(
+                module_src.format(msg="reloaded"),
+                encoding="utf-8",
+            )
+            Ap.Application.loadPythonModule(str(m1_path))
+            assert not capsys.readouterr().out
+            Ap.Application.reloadPythonModule(str(m1_path))
+            assert capsys.readouterr().out == "reloaded\n"
+
+
+class Test_reload_func:
+    @pytest.mark.slow
+    def test_valid(self, capsys: pytest.CaptureFixture[str], tmp_path: Path):
+        with (
+            create_temp_module("Test_reload_func_module_1") as (m1_name, m1_path),
+            create_temp_module("Test_reload_func_module_2") as (m2_name, m2_path),
+        ):
+            log_file = tmp_path / "log.txt"
+            scr_file = tmp_path / "test.scr"
+            m1_path.write_text(
+                "from pyrx.utils.reload import reload\n"  #
+                f"import {m2_name}\n"
+                f"reload('{m2_name}')\n",
+                encoding="utf-8",
+            )
+            m2_path.write_text(
+                f"with open({str(log_file)!r}, 'a', encoding='utf-8') as f:\n"
+                "    print('executed', file=f)\n",
+                encoding="utf-8",
+            )
+            scr = (
+                f'(adspyload "{m1_path.as_posix()}")\n'  #
+                f'(adspyreload "{m1_path.as_posix()}")\n'
+                "_QUIT\n_YES\n"
+            )
+            scr_file.write_text(scr, encoding="ansi")
+            proc = subprocess.Popen(
+                [
+                    Ax.AcadApplication().fullName(),
+                    "/ld",
+                    str(
+                        Path(Ap.Application().getPyRxModulePath())
+                        / Ap.Application().getPyRxModuleName()
+                    ),
+                    "/b",
+                    str(scr_file),
+                ]
+            )
+            TIMEOUT = 50
+            try:
+                proc.wait(timeout=TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                raise
+            assert log_file.read_text(encoding="utf-8") == "executed\nexecuted\n"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Functions to deal with module reloading. The main task is to reload all modules used by the reloaded module :)

Unfortunately I had to start new host instances for testing again..

```py
from pyrx import reload
import my_package.my_module
import my_module_2

reload("my_package", "my_module_2")

# ...
```
