### PR TITLE
Decouple pyi generation from RX

### DIFF
--- a/gen_pyi.py
+++ b/gen_pyi.py
@@ -9,7 +9,7 @@ from typing import Iterable
 
 from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
 from pyrx.doc_utils.misc import DocstringsManager, ReturnTypesManager
-from pyrx.doc_utils.pyi_gen import gen_pyi
+from pyrx.doc_utils.pyi_gen import gen_pyi, BoostPythonTypes
 from pyrx.doc_utils.rx_meta import PyRxModule
 
 if "BRX" in Ap.Application.hostAPI():
@@ -36,12 +36,19 @@ def _run(all_modules: Iterable[ModuleType], log_filename: str = "gen_pyi.log") -
     all_py_rx_modules = [PyRxModule(module) for module in all_modules]
     docstrings = DocstringsManager.from_json()
     return_types = ReturnTypesManager.from_json()
+    boost_types = BoostPythonTypes(
+        Db.OpenMode.__base__,
+        Db.Database.__base__.__base__,
+        type(Db.curDb),
+        type(Ge.Point3d.__dict__["kOrigin"])
+    )
     for module in all_modules:
         res = gen_pyi(
             module=module,
             all_modules=all_py_rx_modules,
             docstrings=docstrings,
             return_types=return_types,
+            boost_types=boost_types,
         ).gen()
         with open(PYI_DIR / f"{module.__name__}.pyi", "w", encoding="utf-8") as f:
             f.write(res)

--- a/gen_pyi.py
+++ b/gen_pyi.py
@@ -9,8 +9,8 @@ from typing import Iterable
 
 from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
 from pyrx.doc_utils.misc import DocstringsManager, ReturnTypesManager
-from pyrx.doc_utils.pyi_gen import gen_pyi, BoostPythonTypes
-from pyrx.doc_utils.rx_meta import PyRxModule
+from pyrx.doc_utils.pyi_gen import gen_pyi
+from pyrx.doc_utils.rx_meta import PyRxModule, RX_BOOST_TYPES
 
 if "BRX" in Ap.Application.hostAPI():
     from pyrx import Bim, Brx, Cv
@@ -36,19 +36,13 @@ def _run(all_modules: Iterable[ModuleType], log_filename: str = "gen_pyi.log") -
     all_py_rx_modules = [PyRxModule(module) for module in all_modules]
     docstrings = DocstringsManager.from_json()
     return_types = ReturnTypesManager.from_json()
-    boost_types = BoostPythonTypes(
-        Db.OpenMode.__base__,
-        Db.Database.__base__.__base__,
-        type(Db.curDb),
-        type(Ge.Point3d.__dict__["kOrigin"])
-    )
     for module in all_modules:
         res = gen_pyi(
             module=module,
             all_modules=all_py_rx_modules,
             docstrings=docstrings,
             return_types=return_types,
-            boost_types=boost_types,
+            boost_types=RX_BOOST_TYPES,
         ).gen()
         with open(PYI_DIR / f"{module.__name__}.pyi", "w", encoding="utf-8") as f:
             f.write(res)

--- a/gen_pyi.py
+++ b/gen_pyi.py
@@ -5,10 +5,12 @@ import subprocess
 import traceback
 from pathlib import Path
 from types import ModuleType
+from typing import Iterable
 
 from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
 from pyrx.doc_utils.misc import DocstringsManager, ReturnTypesManager
-from pyrx.doc_utils.pyi_gen import gen_pyi, _PyRxModule
+from pyrx.doc_utils.pyi_gen import gen_pyi
+from pyrx.doc_utils.rx_meta import PyRxModule
 
 if "BRX" in Ap.Application.hostAPI():
     from pyrx import Bim, Brx, Cv
@@ -28,13 +30,14 @@ def PyRxCmd_gen_pyi():
         traceback.print_exc()
 
 
-def _run(all_modules: tuple[_PyRxModule | str | ModuleType, ...], log_filename: str = "gen_pyi.log") -> None:
+def _run(all_modules: Iterable[ModuleType], log_filename: str = "gen_pyi.log") -> None:
     logging.basicConfig(filename=log_filename, filemode="w", force=True)
     PYI_DIR = Path(__file__).parent / "pyrx"
+    all_py_rx_modules = [PyRxModule(module) for module in all_modules]
     for module in all_modules:
         res = gen_pyi(
             module=module,
-            all_modules=all_modules,
+            all_modules=all_py_rx_modules,
             docstrings=DocstringsManager.from_json(),
             return_types=ReturnTypesManager.from_json(),
         ).gen()

--- a/gen_pyi.py
+++ b/gen_pyi.py
@@ -34,12 +34,14 @@ def _run(all_modules: Iterable[ModuleType], log_filename: str = "gen_pyi.log") -
     logging.basicConfig(filename=log_filename, filemode="w", force=True)
     PYI_DIR = Path(__file__).parent / "pyrx"
     all_py_rx_modules = [PyRxModule(module) for module in all_modules]
+    docstrings = DocstringsManager.from_json()
+    return_types = ReturnTypesManager.from_json()
     for module in all_modules:
         res = gen_pyi(
             module=module,
             all_modules=all_py_rx_modules,
-            docstrings=DocstringsManager.from_json(),
-            return_types=ReturnTypesManager.from_json(),
+            docstrings=docstrings,
+            return_types=return_types,
         ).gen()
         with open(PYI_DIR / f"{module.__name__}.pyi", "w", encoding="utf-8") as f:
             f.write(res)

--- a/gen_pyi.py
+++ b/gen_pyi.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import logging
 import subprocess
 import traceback
 from pathlib import Path
+from types import ModuleType
 
 from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
 from pyrx.doc_utils.misc import DocstringsManager, ReturnTypesManager
-from pyrx.doc_utils.pyi_gen import gen_pyi
+from pyrx.doc_utils.pyi_gen import gen_pyi, _PyRxModule
 
 if "BRX" in Ap.Application.hostAPI():
     from pyrx import Bim, Brx, Cv
@@ -25,13 +28,13 @@ def PyRxCmd_gen_pyi():
         traceback.print_exc()
 
 
-def runBRX():
-    logging.basicConfig(filename="gen_pyi_brx.log", filemode="w", force=True)
+def _run(all_modules: tuple[_PyRxModule | str | ModuleType, ...], log_filename: str = "gen_pyi.log") -> None:
+    logging.basicConfig(filename=log_filename, filemode="w", force=True)
     PYI_DIR = Path(__file__).parent / "pyrx"
-    for module in (Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax, Cv, Bim, Brx):
+    for module in all_modules:
         res = gen_pyi(
             module=module,
-            all_modules=(Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax, Cv, Bim, Brx),
+            all_modules=all_modules,
             docstrings=DocstringsManager.from_json(),
             return_types=ReturnTypesManager.from_json(),
         ).gen()
@@ -41,20 +44,12 @@ def runBRX():
     subprocess.run(["ruff", "check", "--fix", "pyrx"], check=True)
 
 
-def runARX():
-    logging.basicConfig(filename="gen_pyi.log", filemode="w", force=True)
-    PYI_DIR = Path(__file__).parent / "pyrx"
-    for module in (Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm):
-        res = gen_pyi(
-            module=module,
-            all_modules=(Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax),
-            docstrings=DocstringsManager.from_json(),
-            return_types=ReturnTypesManager.from_json(),
-        ).gen()
-        with open(PYI_DIR / f"{module.__name__}.pyi", "w", encoding="utf-8") as f:
-            f.write(res)
+def runBRX() -> None:
+    _run(all_modules=(Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax, Cv, Bim, Brx), log_filename="gen_pyi_brx.log")
 
-    subprocess.run(["ruff", "check", "--fix", "pyrx"], check=True)
+
+def runARX() -> None:
+    _run(all_modules=(Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm))
 
 
 def OnPyReload():

--- a/pyrx/doc_utils/boost_meta.py
+++ b/pyrx/doc_utils/boost_meta.py
@@ -6,7 +6,7 @@ T = TypeVar("T")
 class _BoostPythonEnumMeta(type):
     # This is not a real class, it is just for better type hints
 
-    def __call__(cls: type[T], value: int) -> T: ...
+    def __call__(cls: type[T], value: int) -> T: ...  # type: ignore[empty-body]
 
 
 class _BoostPythonEnum(int, metaclass=_BoostPythonEnumMeta):

--- a/pyrx/doc_utils/boost_meta.py
+++ b/pyrx/doc_utils/boost_meta.py
@@ -1,0 +1,18 @@
+from typing import Self, ClassVar, TypeVar
+
+T = TypeVar("T")
+
+
+class _BoostPythonEnumMeta(type):
+    # This is not a real class, it is just for better type hints
+
+    def __call__(cls: type[T], value: int) -> T: ...
+
+
+class _BoostPythonEnum(int, metaclass=_BoostPythonEnumMeta):
+    # This is not a real class, it is just for better type hints
+
+    values: ClassVar[dict[int, Self]]
+    names: ClassVar[dict[str, Self]]
+
+    name: str

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -346,7 +346,7 @@ class _BoostPythonInstanceClassPyiGenerator:
         )
         return f"{indent}{name}: {type_name}\n"
 
-    def _write_builtin_init(self):
+    def _write_builtin_init(self) -> str:
         indent = self.indent + 1
         indent_2 = indent + 1
         return (
@@ -441,7 +441,7 @@ class _ModulePyiGenerator:
             chunks.append("from pyrx.doc_utils.boost_meta import _BoostPythonEnum\n")
         return "".join(chunks)
 
-    def _write_pyrx_import(self):
+    def _write_pyrx_import(self) -> str:
         return (
             "\n".join(
                 f"from pyrx import {module.module_name} as {module.orig_module_name}"
@@ -450,7 +450,7 @@ class _ModulePyiGenerator:
             + "\n"
         )
 
-    def _skip_member(self, name: str, obj):
+    def _skip_member(self, name: str, obj) -> bool:
         if name.startswith("__") and name.endswith("__"):
             return True
         return False

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -8,14 +8,7 @@ import textwrap
 import types
 import typing as t
 
-__isbrx__ = False
-from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
-
-if "BRX" in Ap.Application.hostAPI():
-    from pyrx import Bim, Brx, Cv
-
-    __isbrx__ = True
-
+from pyrx import Db, Ge
 from .misc import DocstringsManager, ReturnTypesManager
 from .parse_docstring import (
     get_base_signature,
@@ -378,7 +371,7 @@ class _BoostPythonInstanceClassPyiGenerator:
         return _ClsMemberData(signatures, return_type, docstring)
 
 
-class _PyRxModule(str, enum.Enum):
+class PyBoostModule(str, enum.Enum):
     module: types.ModuleType
     module_name: str
     orig_module_name: str
@@ -391,22 +384,6 @@ class _PyRxModule(str, enum.Enum):
         obj.orig_module_name = orig_module_name
         return obj
 
-    Ap = "Ap", Ap, "PyAp"
-    Br = "Br", Br, "PyBr"
-    Db = "Db", Db, "PyDb"
-    Ed = "Ed", Ed, "PyEd"
-    Ge = "Ge", Ge, "PyGe"
-    Gi = "Gi", Gi, "PyGi"
-    Gs = "Gs", Gs, "PyGs"
-    Pl = "Pl", Pl, "PyPl"
-    Rx = "Rx", Rx, "PyRx"
-    Sm = "Sm", Sm, "PySm"
-    Ax = "Ax", Ax, "PyAx"
-    if __isbrx__:
-        Cv = "Cv", Cv, "PyBrxCv"
-        Bim = "Bim", Bim, "PyBrxBim"
-        Brx = "Brx", Brx, "PyBrx"
-
     @classmethod
     def _missing_(cls, value):
         for item in cls:
@@ -418,13 +395,13 @@ class _ModulePyiGenerator:
     def __init__(
         self,
         module: types.ModuleType,
-        all_modules: tuple[_PyRxModule | str | types.ModuleType, ...],
+        all_modules: t.Iterable[PyBoostModule],
         docstrings: DocstringsManager,
         return_types: ReturnTypesManager,
         line_length=LINE_LENGTH,
     ):
         self.module = module
-        self.all_modules = tuple(_PyRxModule(i) for i in all_modules)
+        self.all_modules = list(all_modules)
         self.docstrings = docstrings
         self.return_types = return_types
         self.line_length = line_length
@@ -558,16 +535,11 @@ class _ModulePyiGenerator:
         return "".join(chunks)
 
 
-_all_modules = [Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm]
-if "BRX" in Ap.Application.hostAPI():
-    _all_modules.extend([Cv, Bim, Brx])
-
-
 class TypeFixer:
     def __init__(
         self,
         module: types.ModuleType,
-        all_modules: c.Iterable[_PyRxModule] = (_PyRxModule(m) for m in _all_modules),
+        all_modules: c.Iterable[PyBoostModule],
     ):
         self.module = module
         self.all_modules = tuple(all_modules)
@@ -595,7 +567,7 @@ class TypeFixer:
 
 def gen_pyi(
     module: types.ModuleType,
-    all_modules: tuple[_PyRxModule | str | types.ModuleType, ...],
+    all_modules: t.Iterable[PyBoostModule],
     docstrings: DocstringsManager,
     return_types: ReturnTypesManager,
     line_length=LINE_LENGTH,

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -417,24 +417,6 @@ class _PyRxModule(str, enum.Enum):
                 return item
 
 
-_BoostPythonEnum_source = """
-T = TypeVar("T")
-
-class _BoostPythonEnumMeta(type):
-    # This is not a real class, it is just for better type hints
-
-    def __call__(cls: type[T], value: int) -> T: ...
-
-class _BoostPythonEnum(int, metaclass=_BoostPythonEnumMeta):
-    # This is not a real class, it is just for better type hints
-
-    values: ClassVar[dict[int, Self]]
-    names: ClassVar[dict[str, Self]]
-
-    name: str
-"""
-
-
 class _ModulePyiGenerator:
     def __init__(
         self,
@@ -464,7 +446,7 @@ class _ModulePyiGenerator:
         chunks.append(self._write_pyrx_import())
         chunks.append("import wx\n")
         if enums:
-            chunks.append(self._write_boost_python_enum_source())
+            chunks.append("from pyrx.doc_utils.boost_meta import _BoostPythonEnum\n")
         return "".join(chunks)
 
     def _write_pyrx_import(self):
@@ -475,9 +457,6 @@ class _ModulePyiGenerator:
             )
             + "\n"
         )
-
-    def _write_boost_python_enum_source(self):
-        return _BoostPythonEnum_source
 
     def _skip_member(self, name: str, obj):
         if name.startswith("__") and name.endswith("__"):

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -7,7 +7,6 @@ import logging
 import textwrap
 import types
 import typing as t
-from typing import NamedTuple
 
 from pyrx import Db, Ge
 from .boost_meta import _BoostPythonEnum
@@ -26,15 +25,16 @@ LINE_LENGTH = 99
 
 class BoostPythonEnum(_BoostPythonEnum): pass
 class BoostPythonInstance(t.Protocol): pass
-class BoostPythonFunction(t.Protocol): pass
+class BoostPythonFunction(t.Protocol):
+    def __call__(self, *args, **kwargs) -> t.Any: ...
 class BoostPythonStaticProperty(t.Protocol): pass
 
 
-class BoostPythonTypes(NamedTuple):
-    enum: t.Type[BoostPythonEnum]
-    instance: t.Type[BoostPythonInstance]
-    function: t.Type[BoostPythonFunction]
-    static_property: t.Type[BoostPythonStaticProperty]
+class BoostPythonTypes(t.NamedTuple):
+    enum: t.Type[BoostPythonEnum] = BoostPythonEnum
+    instance: t.Type[BoostPythonInstance] = object
+    function: t.Type[BoostPythonFunction] = types.FunctionType
+    static_property: t.Type[BoostPythonStaticProperty] = property
 
 
 BOOST = BoostPythonTypes(

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -8,7 +8,6 @@ import textwrap
 import types
 import typing as t
 
-from pyrx import Db, Ge
 from .boost_meta import _BoostPythonEnum
 from .misc import DocstringsManager, ReturnTypesManager
 from .parse_docstring import (
@@ -35,14 +34,6 @@ class BoostPythonTypes(t.NamedTuple):
     instance: t.Type[BoostPythonInstance] = object
     function: t.Type[BoostPythonFunction] = types.FunctionType
     static_property: t.Type[BoostPythonStaticProperty] = property
-
-
-BOOST = BoostPythonTypes(
-    Db.OpenMode.__base__,
-    Db.Database.__base__.__base__,
-    type(Db.curDb),
-    type(Ge.Point3d.__dict__["kOrigin"])
-)
 
 
 class Indent:
@@ -229,7 +220,7 @@ class _BoostPythonInstanceClassPyiGenerator:
         type_fixer: TypeFixer,
         indent: Indent | int = 0,
         line_length=LINE_LENGTH,
-        boost_types: BoostPythonTypes = BOOST,
+        boost_types: BoostPythonTypes = BoostPythonTypes(),
     ):
         self.docstrings = docstrings
         self.return_types = return_types
@@ -419,7 +410,7 @@ class _ModulePyiGenerator:
         docstrings: DocstringsManager,
         return_types: ReturnTypesManager,
         line_length=LINE_LENGTH,
-        boost_types: BoostPythonTypes = BOOST,
+        boost_types: BoostPythonTypes = BoostPythonTypes(),
     ):
         self.module = module
         self.all_modules = list(all_modules)
@@ -594,7 +585,7 @@ def gen_pyi(
     docstrings: DocstringsManager,
     return_types: ReturnTypesManager,
     line_length=LINE_LENGTH,
-    boost_types: BoostPythonTypes = BOOST,
+    boost_types: BoostPythonTypes = BoostPythonTypes(),
 ):
     return _ModulePyiGenerator(
         module=module,

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -225,19 +225,16 @@ class _BoostPythonInstanceClassPyiGenerator:
         self.line_length = line_length
         self.type_fixer = type_fixer
 
-    def _skip_member(self, name, obj):
-        if name in {
-            "__repr__",
-            "__str__",
-            "__eq__",
-            "__bool__",
-            "__doc__",
-            "__module__",
-            "__instance_size__",
-            "__safe_for_unpickling__",
-        }:
-            return True
-        return False
+    _MEMBERS_TO_SKIP = {
+        "__repr__",
+        "__str__",
+        "__eq__",
+        "__bool__",
+        "__doc__",
+        "__module__",
+        "__instance_size__",
+        "__safe_for_unpickling__",
+    }
 
     def gen(self, cls: BoostPythonInstance, module_name: str):
         indent = self.indent
@@ -256,7 +253,7 @@ class _BoostPythonInstanceClassPyiGenerator:
         for cls_member_name, cls_member in inspect.getmembers(cls):
             if cls_member_name not in cls_dict:  # skip methods inherited from base classes
                 continue
-            if self._skip_member(cls_member_name, cls_member):
+            if cls_member_name in self._MEMBERS_TO_SKIP:
                 continue
             if inspect.ismethoddescriptor(cls_member):  # method or staticmethod
                 s = self._write_method(

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -30,7 +30,7 @@ BoostPythonStaticProperty = type(Ge.Point3d.__dict__["kOrigin"])
 class Indent:
     def __init__(self, indent: int | Indent = 0, /):
         if isinstance(indent, Indent):
-            self._indent = indent._indent
+            self._indent: int = indent._indent
         elif isinstance(indent, int):
             self._indent = indent
         else:
@@ -81,11 +81,11 @@ class DocstringTextWrapper(textwrap.TextWrapper):
         indent: int | Indent,
         width=LINE_LENGTH,
     ):
-        indent = str(Indent(indent))
+        indent_str = str(Indent(indent))
         super().__init__(
             width,
-            initial_indent=indent,
-            subsequent_indent=indent,
+            initial_indent=indent_str,
+            subsequent_indent=indent_str,
             expand_tabs=False,
             replace_whitespace=False,
             break_long_words=False,
@@ -198,7 +198,7 @@ def write_method(
 
 
 class _ClsMemberData(t.NamedTuple):
-    signatures: tuple[str] | None = None
+    signatures: tuple[str, ...] | None = None
     return_type: str | None = None
     docstring: str | None = None
 
@@ -437,7 +437,7 @@ class _ModulePyiGenerator:
             return True
         return False
 
-    def gen(self):
+    def gen(self) -> str:
         module = self.module
         module_name = module.__name__
         classes: list[tuple[str, type]] = []

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 
 LINE_LENGTH = 99
 
-class BoostPythonEnum(_BoostPythonEnum): pass
-class BoostPythonInstance(t.Protocol): pass
+class BoostPythonEnum(_BoostPythonEnum): ...
+class BoostPythonInstance(t.Protocol): ...
 class BoostPythonFunction(t.Protocol):
     def __call__(self, *args, **kwargs) -> t.Any: ...
-class BoostPythonStaticProperty(t.Protocol): pass
+class BoostPythonStaticProperty(t.Protocol): ...
 
 
 class BoostPythonTypes(t.NamedTuple):

--- a/pyrx/doc_utils/rx_meta.py
+++ b/pyrx/doc_utils/rx_meta.py
@@ -1,0 +1,27 @@
+from pyrx.doc_utils.pyi_gen import PyBoostModule
+
+__isbrx__ = False
+from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
+
+if "BRX" in Ap.Application.hostAPI():
+    from pyrx import Bim, Brx, Cv
+
+    __isbrx__ = True
+
+
+class PyRxModule(PyBoostModule):
+    Ap = "Ap", Ap, "PyAp"
+    Br = "Br", Br, "PyBr"
+    Db = "Db", Db, "PyDb"
+    Ed = "Ed", Ed, "PyEd"
+    Ge = "Ge", Ge, "PyGe"
+    Gi = "Gi", Gi, "PyGi"
+    Gs = "Gs", Gs, "PyGs"
+    Pl = "Pl", Pl, "PyPl"
+    Rx = "Rx", Rx, "PyRx"
+    Sm = "Sm", Sm, "PySm"
+    Ax = "Ax", Ax, "PyAx"
+    if __isbrx__:
+        Cv = "Cv", Cv, "PyBrxCv"
+        Bim = "Bim", Bim, "PyBrxBim"
+        Brx = "Brx", Brx, "PyBrx"

--- a/pyrx/doc_utils/rx_meta.py
+++ b/pyrx/doc_utils/rx_meta.py
@@ -1,4 +1,4 @@
-from pyrx.doc_utils.pyi_gen import PyBoostModule
+from pyrx.doc_utils.pyi_gen import PyBoostModule, BoostPythonTypes
 
 __isbrx__ = False
 from pyrx import Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm
@@ -25,3 +25,11 @@ class PyRxModule(PyBoostModule):
         Cv = "Cv", Cv, "PyBrxCv"
         Bim = "Bim", Bim, "PyBrxBim"
         Brx = "Brx", Brx, "PyBrx"
+
+
+RX_BOOST_TYPES = BoostPythonTypes(
+    Db.OpenMode.__base__,
+    Db.Database.__base__.__base__,
+    type(Db.curDb),
+    type(Ge.Point3d.__dict__["kOrigin"])
+)

--- a/tests/test_doc_utils/test_pyi_gen.py
+++ b/tests/test_doc_utils/test_pyi_gen.py
@@ -14,7 +14,7 @@ from pyrx.doc_utils.pyi_gen import (
     wrap_docstring,
     write_method,
 )
-from pyrx.doc_utils.rx_meta import PyRxModule
+from pyrx.doc_utils.rx_meta import PyRxModule, RX_BOOST_TYPES
 
 _all_modules = [Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm]
 if "BRX" in Ap.Application.hostAPI():
@@ -316,6 +316,7 @@ def test_BoostPythonInstanceClassPyiGenerator(
         type_fixer=TypeFixer(module, all_modules=_all_modules),
         indent=indent,
         line_length=line_length,
+        boost_types=RX_BOOST_TYPES,
     )
     res = obj.gen(cls=cls, module_name=module_name)
     for expected_chunk in expected:
@@ -366,6 +367,7 @@ class Test_ModulePyiGenerator:
             docstrings=docstrings,
             return_types=return_types,
             line_length=99,
+            boost_types=RX_BOOST_TYPES,
         )
         res = obj._write_boost_python_enum_class(cls_name, cls_obj)
         for expected_chunk in expected:
@@ -396,6 +398,7 @@ class Test_ModulePyiGenerator:
             docstrings=docstrings,
             return_types=return_types,
             line_length=99,
+            boost_types=RX_BOOST_TYPES,
         )
         res = obj._write_global_enum_member(enum_name, enum_obj)
         for expected_chunk in expected:
@@ -422,6 +425,7 @@ class Test_ModulePyiGenerator:
             docstrings=docstrings,
             return_types=return_types,
             line_length=99,
+            boost_types=RX_BOOST_TYPES,
         )
         res = obj.gen()
         for expected_chunk in expected:

--- a/tests/test_doc_utils/test_pyi_gen.py
+++ b/tests/test_doc_utils/test_pyi_gen.py
@@ -11,10 +11,16 @@ from pyrx.doc_utils.pyi_gen import (
     TypeFixer,
     _BoostPythonInstanceClassPyiGenerator,
     _ModulePyiGenerator,
-    _PyRxModule,
     wrap_docstring,
     write_method,
 )
+from pyrx.doc_utils.rx_meta import PyRxModule
+
+_all_modules = [Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm]
+if "BRX" in Ap.Application.hostAPI():
+    from pyrx import Cv, Bim, Brx
+    _all_modules.extend([Cv, Bim, Brx])
+
 
 logger = logging.getLogger(__name__)
 
@@ -307,7 +313,7 @@ def test_BoostPythonInstanceClassPyiGenerator(
     obj = _BoostPythonInstanceClassPyiGenerator(
         docstrings=docstrings,
         return_types=return_types,
-        type_fixer=TypeFixer(module),
+        type_fixer=TypeFixer(module, all_modules=_all_modules),
         indent=indent,
         line_length=line_length,
     )
@@ -321,8 +327,8 @@ def test_BoostPythonInstanceClassPyiGenerator(
 
 
 def test_PyRxModule():
-    obj = _PyRxModule.Db
-    assert _PyRxModule("PyDb") is _PyRxModule("Db") is _PyRxModule(Db) is obj
+    obj = PyRxModule.Db
+    assert PyRxModule("PyDb") is PyRxModule("Db") is PyRxModule(Db) is obj
     assert obj.module_name == "Db"
     assert obj.orig_module_name == "PyDb"
     assert obj.module == Db


### PR DESCRIPTION
## Description

This pull request removes all direct dependencies to `Ax`, `Ar`, `Db`... modules in `pyi_gen.py`, using dependency injection. This was done for two main reasons:
  - Prepare for a next pull request that will add *pytest* in the CI. As any dependency to the CAD is hard to manage and compile, a first goal would be to test everything that does not depend on them.
  - Re-usability: as `boost::python` [does not support the stubs generation]https://github.com/boostorg/python/issues/277), this system might be useful in other projects and contexts

I made sure that `pyi_gen.py` passes with *mypy* and *pyright*, as adding one of those tools to the CI might be useful at some point too.