### PR TITLE
Fix tests not passing in test_pyi_gen.py

### DIFF
--- a/gen_pyi.py
+++ b/gen_pyi.py
@@ -51,7 +51,7 @@ def _run(all_modules: Iterable[ModuleType], log_filename: str = "gen_pyi.log") -
 
 
 def runBRX() -> None:
-    _run(all_modules=(Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax, Cv, Bim, Brx), log_filename="gen_pyi_brx.log")
+    _run(all_modules=(Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Cv, Bim, Brx), log_filename="gen_pyi_brx.log")
 
 
 def runARX() -> None:

--- a/pyrx/PyAp.pyi
+++ b/pyrx/PyAp.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Ap as PyAp
 from pyrx import Ax as PyAx
 from pyrx import Db as PyDb

--- a/pyrx/PyAx.pyi
+++ b/pyrx/PyAx.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, Collection, Iterator, overload
+from typing import Any, ClassVar, Collection, Iterator, Self, overload
 from pyrx import Ax as PyAx
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe

--- a/pyrx/PyBr.pyi
+++ b/pyrx/PyBr.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any
+from typing import Any, ClassVar, Self
 from pyrx import Br as PyBr
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe

--- a/pyrx/PyBrx.pyi
+++ b/pyrx/PyBrx.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any
+from typing import Any, ClassVar, Self
 from pyrx import Db as PyDb
 from pyrx import Brx as PyBrx
 import wx

--- a/pyrx/PyBrxBim.pyi
+++ b/pyrx/PyBrxBim.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe
 from pyrx import Bim as PyBrxBim

--- a/pyrx/PyBrxCv.pyi
+++ b/pyrx/PyBrxCv.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe
 from pyrx import Rx as PyRx

--- a/pyrx/PyDb.pyi
+++ b/pyrx/PyDb.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, Collection, Iterator, overload
+from typing import Any, ClassVar, Collection, Iterator, Self, overload
 from pyrx import Ax as PyAx
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe

--- a/pyrx/PyEd.pyi
+++ b/pyrx/PyEd.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, Collection, Iterator, overload
+from typing import Any, ClassVar, Collection, Iterator, Self, overload
 from pyrx import Ap as PyAp
 from pyrx import Db as PyDb
 from pyrx import Ed as PyEd

--- a/pyrx/PyGe.pyi
+++ b/pyrx/PyGe.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Ge as PyGe
 from pyrx.doc_utils.boost_meta import _BoostPythonEnum
 Helix: EntityId  # 80

--- a/pyrx/PyGi.pyi
+++ b/pyrx/PyGi.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe
 from pyrx import Gi as PyGi

--- a/pyrx/PyGs.pyi
+++ b/pyrx/PyGs.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any
+from typing import Any, ClassVar, Self
 from pyrx import Db as PyDb
 from pyrx import Ge as PyGe
 from pyrx import Gs as PyGs

--- a/pyrx/PyPl.pyi
+++ b/pyrx/PyPl.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Db as PyDb
 from pyrx import Pl as PyPl
 from pyrx import Rx as PyRx

--- a/pyrx/PyRx.pyi
+++ b/pyrx/PyRx.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any
+from typing import Any, ClassVar, Self
 from pyrx import Rx as PyRx
 from pyrx.doc_utils.boost_meta import _BoostPythonEnum
 kAngle: LispType  # 5004

--- a/pyrx/PySm.pyi
+++ b/pyrx/PySm.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import ClassVar, Self, Any, overload
+from typing import Any, ClassVar, Self, overload
 from pyrx import Db as PyDb
 from pyrx import Sm as PySm
 from pyrx.doc_utils.boost_meta import _BoostPythonEnum

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -430,7 +430,7 @@ class _ModulePyiGenerator:
 
     def _write_module_header(self, enums: bool):
         chunks: list[str] = ["from __future__ import annotations\n"]
-        chunks.append("from typing import TypeVar, ClassVar, Self, Any, Collection, Iterator, overload\n")
+        chunks.append("from typing import Any, ClassVar, Collection, Iterator, Self, TypeVar, overload\n")
         chunks.append(self._write_pyrx_import())
         chunks.append("import wx\n")
         if enums:

--- a/pyrx/doc_utils/pyi_gen.py
+++ b/pyrx/doc_utils/pyi_gen.py
@@ -430,7 +430,7 @@ class _ModulePyiGenerator:
 
     def _write_module_header(self, enums: bool):
         chunks: list[str] = ["from __future__ import annotations\n"]
-        chunks.append("from typing import Any, ClassVar, Collection, Iterator, Self, TypeVar, overload\n")
+        chunks.append("from typing import Any, ClassVar, Collection, Iterator, Self, overload\n")
         chunks.append(self._write_pyrx_import())
         chunks.append("import wx\n")
         if enums:

--- a/pyrx/doc_utils/rx_meta.py
+++ b/pyrx/doc_utils/rx_meta.py
@@ -11,6 +11,7 @@ if "BRX" in Ap.Application.hostAPI():
 
 class PyRxModule(PyBoostModule):
     Ap = "Ap", Ap, "PyAp"
+    Ax = "Ax", Ax, "PyAx"
     Br = "Br", Br, "PyBr"
     Db = "Db", Db, "PyDb"
     Ed = "Ed", Ed, "PyEd"
@@ -20,7 +21,6 @@ class PyRxModule(PyBoostModule):
     Pl = "Pl", Pl, "PyPl"
     Rx = "Rx", Rx, "PyRx"
     Sm = "Sm", Sm, "PySm"
-    Ax = "Ax", Ax, "PyAx"
     if __isbrx__:
         Cv = "Cv", Cv, "PyBrxCv"
         Bim = "Bim", Bim, "PyBrxBim"

--- a/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Db.AbstractViewTableRecord.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Db.AbstractViewTableRecord.txt
@@ -21,6 +21,7 @@
         def setUcs(self, view: PyDb.OrthographicView, /) -> None: ...
         @overload
         def setUcs(self, ucsId: PyDb.ObjectId, /) -> None: ...
+        @overload
         def setUcs(self, *args) -> None:
             """
             This function sets the UCS for the view or viewport table record. The new

--- a/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Ed.Editor.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Ed.Editor.txt
@@ -6,6 +6,7 @@ class Editor:
     @overload
     @staticmethod
     def getPoint(basePt: PyGe.Point3d, prompt: str, /) -> tuple[PyEd.PromptStatus, PyGe.Point3d]: ...
+    @overload
     @staticmethod
     def getPoint(*args) -> tuple[PyEd.PromptStatus, PyGe.Point3d]:
         """

--- a/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Ge.Point3d.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Ge.Point3d.txt
@@ -8,17 +8,14 @@ class Point3d:
     def __init__(self, x: float,y: float,z: float, /) -> None: ...
     @overload
     def __init__(self, pln: PyGe.PlanarEnt, pnt2d: PyGe.Point2d, /) -> None: ...
-    def __init__(self, *args) -> None:
-        pass
+    @overload
+    def __init__(self, *args) -> None: ...
 # (...) #
     kOrigin: PyGe.Point3d
 # (...) #
     @property
-    def x(self, /) -> float:
-        pass
+    def x(self, /) -> float: ...
     @property
-    def y(self, /) -> float:
-        pass
+    def y(self, /) -> float: ...
     @property
-    def z(self, /) -> float:
-        pass
+    def z(self, /) -> float: ...

--- a/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Gi.CommonDraw.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Gi.CommonDraw.txt
@@ -1,5 +1,5 @@
 class CommonDraw(PyRx.RxObject):
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Raises an exception.
         This class cannot be instantiated from Python.

--- a/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
@@ -14,27 +14,12 @@ from pyrx import Sm as PySm
 import wx
 from pyrx.doc_utils.boost_meta import _BoostPythonEnum
 # (...) #
-T = TypeVar("T")
-
-class _BoostPythonEnumMeta(type):
-    # This is not a real class, it is just for better type hints
-
-    def __call__(cls: type[T], value: int) -> T: ...
-
-class _BoostPythonEnum(int, metaclass=_BoostPythonEnumMeta):
-    # This is not a real class, it is just for better type hints
-
-    values: ClassVar[dict[int, Self]]
-    names: ClassVar[dict[str, Self]]
-
-    name: str
-# (...) #
 kForReadAndAllShare: DatabaseOpenMode  # 3
 # (...) #
 class AbstractViewTableRecord(PyDb.SymbolTableRecord):
     def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None: ...
 # (...) #
-    def __reduce__(self, /): ...
+    def __reduce__(self, /) -> Any: ...
 # (...) #
     def centerPoint(self, /) -> PyGe.Point2d:
         """

--- a/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Any, ClassVar, Collection, Iterator, Self, overload
 from pyrx import Ap as PyAp
+from pyrx import Ax as PyAx
 from pyrx import Br as PyBr
 from pyrx import Db as PyDb
 from pyrx import Ed as PyEd
@@ -10,8 +11,8 @@ from pyrx import Gs as PyGs
 from pyrx import Pl as PyPl
 from pyrx import Rx as PyRx
 from pyrx import Sm as PySm
-from pyrx import Ax as PyAx
 import wx
+from pyrx.doc_utils.boost_meta import _BoostPythonEnum
 # (...) #
 T = TypeVar("T")
 

--- a/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import *
+from typing import Any, ClassVar, Collection, Iterator, Self, overload
 from pyrx import Ap as PyAp
 from pyrx import Br as PyBr
 from pyrx import Db as PyDb

--- a/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
@@ -31,11 +31,9 @@ class _BoostPythonEnum(int, metaclass=_BoostPythonEnumMeta):
 kForReadAndAllShare: DatabaseOpenMode  # 3
 # (...) #
 class AbstractViewTableRecord(PyDb.SymbolTableRecord):
-    def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None:
-        pass
+    def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None: ...
 # (...) #
-    def __reduce__(self, /):
-        pass
+    def __reduce__(self, /): ...
 # (...) #
     def centerPoint(self, /) -> PyGe.Point2d:
         """

--- a/tests/test_doc_utils/test_pyi_gen.py
+++ b/tests/test_doc_utils/test_pyi_gen.py
@@ -313,7 +313,7 @@ def test_BoostPythonInstanceClassPyiGenerator(
     obj = _BoostPythonInstanceClassPyiGenerator(
         docstrings=docstrings,
         return_types=return_types,
-        type_fixer=TypeFixer(module, all_modules=_all_modules),
+        type_fixer=TypeFixer(module, all_modules=[PyRxModule(m) for m in _all_modules]),
         indent=indent,
         line_length=line_length,
         boost_types=RX_BOOST_TYPES,
@@ -419,9 +419,11 @@ class Test_ModulePyiGenerator:
         ),
     )
     def test_gen(self, module, expected, docstrings, return_types):
+        modules = (Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax)
+        boost_modules = [PyRxModule(m) for m in modules]
         obj = _ModulePyiGenerator(
             module=module,
-            all_modules=(Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax),
+            all_modules=boost_modules,
             docstrings=docstrings,
             return_types=return_types,
             line_length=99,

--- a/tests/test_doc_utils/test_pyi_gen.py
+++ b/tests/test_doc_utils/test_pyi_gen.py
@@ -419,7 +419,7 @@ class Test_ModulePyiGenerator:
         ),
     )
     def test_gen(self, module, expected, docstrings, return_types):
-        modules = (Ap, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm, Ax)
+        modules = (Ap, Ax, Br, Db, Ed, Ge, Gi, Gs, Pl, Rx, Sm)
         boost_modules = [PyRxModule(m) for m in modules]
         obj = _ModulePyiGenerator(
             module=module,


### PR DESCRIPTION
This pull request:

- Fixes a few tests that haven't been updated in #261 and #267
- Removes `TypeVar` from the types that are added in the .pyi files, as it is not used and is systematically removed by *ruff*
- Reorders the imports from `typing` following the *isort* convention
- Put the `Ax` module right after `Ap` in sequences where it was mispositioned