### PR TITLE
Fix type hints _PassWorkingDb

### DIFF
--- a/.github/workflows/pytest-check.yml
+++ b/.github/workflows/pytest-check.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Run Pytest
         run: |
           TEST_PATHS=(
-            #    "tests/test_ap",
-            #    "tests/test_commands",
-            #    "tests/test_core",
-            #    "tests/test_db",
-            "tests/test_doc_utils/test_misc.py",
-            "tests/test_doc_utils/test_parse_docstring.py",
-            #    "tests/test_doc_utils/test_pyi_gen.py",
-            #    "tests/test_utils",
-            #    "tests/test_console.py"
+            #    tests/test_ap
+            #    tests/test_commands
+            #    tests/test_core
+            #    tests/test_db
+            tests/test_doc_utils/test_misc.py
+            tests/test_doc_utils/test_parse_docstring.py
+            #    tests/test_doc_utils/test_pyi_gen.py
+            #    tests/test_utils
+            #    tests/test_console.py
           )
           pytest "${TEST_PATHS[@]}"

--- a/.github/workflows/pytest-check.yml
+++ b/.github/workflows/pytest-check.yml
@@ -25,4 +25,16 @@ jobs:
           pip install -e .[dev]
 
       - name: Run Pytest
-        run: pytest
+        run: |
+          TEST_PATHS=(
+            #    "tests/test_ap",
+            #    "tests/test_commands",
+            #    "tests/test_core",
+            #    "tests/test_db",
+            "tests/test_doc_utils/test_misc.py",
+            "tests/test_doc_utils/test_parse_docstring.py",
+            #    "tests/test_doc_utils/test_pyi_gen.py",
+            #    "tests/test_utils",
+            #    "tests/test_console.py"
+          )
+          pytest "${TEST_PATHS[@]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,18 +66,7 @@ Repository = "https://github.com/CEXT-Dan/PyRx"
 Issues = "https://github.com/CEXT-Dan/PyRx/issues"
 
 [tool.pytest.ini_options]
-testpaths = [
-#    "tests/test_ap",
-#    "tests/test_commands",
-#    "tests/test_core",
-#    "tests/test_db",
-    "tests/test_doc_utils/test_misc.py",
-    "tests/test_doc_utils/test_parse_docstring.py",
-#    "tests/test_doc_utils/test_pyi_gen.py",
-#    "tests/test_utils",
-#    "tests/test_console.py"
-]
-
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 99

--- a/pyrx/utils/decorators.py
+++ b/pyrx/utils/decorators.py
@@ -7,11 +7,12 @@ from functools import wraps
 from pyrx import Db
 
 _EMPTY = object()
-T = t.TypeVar("T")
+_P = t.ParamSpec("_P")
+_R = t.TypeVar("_R")
 
 
-class _PassWorkingDb(t.Generic[T]):
-    def __init__(self, func: t.Callable[..., T]):
+class _PassWorkingDb(t.Generic[_P, _R]):
+    def __init__(self, func: t.Callable[_P, _R]):
         self.sig = inspect.signature(func)
         try:
             db_param = self.sig.parameters["db"]
@@ -25,7 +26,7 @@ class _PassWorkingDb(t.Generic[T]):
             raise RuntimeError("Function 'db' parameter must be positional or keyword")
         self.func = func
 
-    def __call__(self, *args, **kwargs) -> T:
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         # fix the parameters to include the working database
         args, kwargs = self.fix_params(args, kwargs)
 
@@ -61,7 +62,7 @@ class _PassWorkingDb(t.Generic[T]):
         return Db.workingDb()
 
 
-def pass_working_db(func: t.Callable[..., T]) -> t.Callable[..., T]:
+def pass_working_db(func: t.Callable[_P, _R]) -> t.Callable[_P, _R]:
     """
     Decorator to ensure the working database is passed to the function.
 

--- a/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Db.AbstractViewTableRecord.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/BoostPythonInstanceClassPyiGenerator/Db.AbstractViewTableRecord.txt
@@ -1,6 +1,10 @@
     class AbstractViewTableRecord(PyDb.SymbolTableRecord):
 # (...) #
-        def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None: ...
+        def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None:
+            """
+            This class is the base class for the AcDbViewTableRecord and AcDbViewportTableRecord
+            classes.
+            """
 # (...) #
         def __reduce__(self, /) -> Any: ...
 # (...) #

--- a/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
+++ b/tests/test_doc_utils/resources/test_pyi_gen/ModulePyiGenerator/Db.txt
@@ -17,7 +17,11 @@ from pyrx.doc_utils.boost_meta import _BoostPythonEnum
 kForReadAndAllShare: DatabaseOpenMode  # 3
 # (...) #
 class AbstractViewTableRecord(PyDb.SymbolTableRecord):
-    def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None: ...
+    def __init__(self, id: PyDb.ObjectId, mode: PyDb.OpenMode = PyDb.OpenMode.kForRead, /) -> None:
+        """
+        This class is the base class for the AcDbViewTableRecord and AcDbViewportTableRecord
+        classes.
+        """
 # (...) #
     def __reduce__(self, /) -> Any: ...
 # (...) #

--- a/tests/test_utils/test_decorators.py
+++ b/tests/test_utils/test_decorators.py
@@ -43,7 +43,7 @@ class Test_pass_working_db:
         mock_db = object()
 
         @pass_working_db
-        def func(*, other, db):
+        def func(*, other, db = ...):
             return other, db
 
         with patch("pyrx.Db.workingDb", return_value=mock_db):


### PR DESCRIPTION
This pull request:

- Fixes type hints that were not precise enough for VSCode (Solves [this thread](https://github.com/CEXT-Dan/PyRx/pull/284#discussion_r2063462268))
- Fixes a regression introduced in #299 where lauching RUNTESTS in the CAD only launched the tests for the CI
- Fixes tests that started failing after adding docstrings to the `AbstractViewTableRecord.__init__` method.