### PR TITLE
add ``PY_WX_INSPECT`` command

### DIFF
--- a/pyrx/_commands.py
+++ b/pyrx/_commands.py
@@ -1,0 +1,4 @@
+from . import command
+from .utils.wx import show_inspection_frame
+
+command(show_inspection_frame, name="PY_WX_INSPECT")

--- a/pyrx/_host_init.py
+++ b/pyrx/_host_init.py
@@ -106,6 +106,7 @@ def main() -> None:
     # pyrx_settings can be modified by onload file so there is getting it again
     # pyrx_settings = get_pyrx_settings()  # uncomment when needed
     # load REPLs
+    import pyrx._commands  # noqa: F401
     import pyrx.repl.repl_cmds  # noqa: F401
 
 

--- a/pyrx/_host_init.py
+++ b/pyrx/_host_init.py
@@ -5,6 +5,8 @@ import logging
 import os
 from pathlib import Path
 
+import wx
+
 from pyrx import Ap, Ed, command, reload
 from pyrx.config import get_pyrx_settings
 from pyrx.PyRxDebug import startListener
@@ -90,6 +92,9 @@ wxRxApp = None
 def main() -> None:
     # init wxApp
     global wxRxApp
+    _ = wx.App()  # if wx.App() is not called,
+    # ``Ap.Application.wxApp()`` will return ``wx._core.PyApp``
+    # instead of ``wx.App``, so e.g. ``wx.CallAfter`` will not work
     wxRxApp = Ap.Application.wxApp()
 
     # reload all pyrx modules if this module is reloaded

--- a/pyrx/utils/wx.py
+++ b/pyrx/utils/wx.py
@@ -1,0 +1,5 @@
+from wx.lib.mixins.inspection import InspectionTool
+
+
+def show_inspection_frame():
+    InspectionTool().Show()

--- a/tests/test_core/test_wx/test_wx.py
+++ b/tests/test_core/test_wx/test_wx.py
@@ -1,36 +1,43 @@
 from __future__ import annotations
-from pyrx import Ap
+
 import wx
+
+from pyrx import Ap
 
 
 class TestWxPython:
-
     def test_get_app(self):  # just test possible types
         pyapp: wx.App = Ap.Application.wxApp()
+        assert isinstance(pyapp, wx.App)
         topWin: wx.Window = pyapp.TopWindow
         assert topWin != None
 
     def test_get_hwnd(self):  # just test possible types
         pyapp: wx.App = Ap.Application.wxApp()
+        assert isinstance(pyapp, wx.App)
         topWin: wx.Window = pyapp.TopWindow
         assert topWin.Handle == Ap.Application.mainWnd()
 
     def test_get_wxapp(self):  # just test possible types
         pyapp: wx.App = wx.App.Get()
+        assert isinstance(pyapp, wx.App)
         topWin: wx.Window = pyapp.TopWindow
         assert topWin != None
 
     def test_get_wxhwnd(self):  # just test possible types
         pyapp: wx.App = wx.App.Get()
+        assert isinstance(pyapp, wx.App)
         topWin: wx.Window = pyapp.TopWindow
         assert topWin.Handle == Ap.Application.mainWnd()
 
     def test_get_wxappget(self):  # just test possible types
         pyapp: wx.App = wx.GetApp()
+        assert isinstance(pyapp, wx.App)
         topWin: wx.Window = pyapp.TopWindow
         assert topWin != None
 
     def test_get_wxhwndget(self):  # just test possible types
         pyapp: wx.App = wx.GetApp()
+        assert isinstance(pyapp, wx.App)
         topWin: wx.Window = pyapp.TopWindow
         assert topWin.Handle == Ap.Application.mainWnd()


### PR DESCRIPTION
Added ``PY_WX_INSPECT`` command to display inspection frame for ``wxpython``.

It was also necessary to change the initialization of wx App. Before calling ``Ap.Application.wxApp()`` it is necessary to call ``wx.App()`` so that ``wx.GetApp()`` (and therefore also ``Ap.Application.wxApp()``) returns the ``wx.App`` object instead of ``wx._core.PyApp``, otherwise e.g. ``wx.CallAfter`` does not work, which is used e.g. during initialization of ``InspectionFrame``.