### PR TITLE
``DynBlockReferenceProperty.setValue`` improve docstring

### DIFF
--- a/pyrx/doc_utils/stubs/PyDb.pyi
+++ b/pyrx/doc_utils/stubs/PyDb.pyi
@@ -20,6 +20,17 @@ from pyrx import Db as PyDb
 
 # pyrx-marker: HEADER_END
 
+class DynBlockReferenceProperty:
+    def setValue(self, val: PyDb.EvalVariant, /) -> None:
+        """
+        Sets the current value of the property on the block.
+
+        **Note**:
+        No error is raised if the specified property value could not be set. For example, if the
+        property has a list of allowable values or a minimum-maximum range and the value provided
+        is not in the list or is out of range, the method succeeds and no error is raised.
+        """
+
 class ErrorStatusException(RuntimeError):
     code: PyDb.ErrorStatus
     message: str

--- a/pyrx/doc_utils/stubs/base.py
+++ b/pyrx/doc_utils/stubs/base.py
@@ -35,7 +35,7 @@ class Node(t.Generic[ASTType_T]):
 
     @property
     def range(self) -> range:
-        return range(self.start_line, self.end_line + 1)
+        return range(self.start_line, self.end_line)
 
     def __str__(self) -> str:
         return (

--- a/tests/test_doc_utils/test_stubs/test_base.py
+++ b/tests/test_doc_utils/test_stubs/test_base.py
@@ -81,83 +81,83 @@ class TestStubParser:
         assert class_Class.name == "Class"
         assert class_Class.start_line == 7
         assert class_Class.end_line == 44
-        assert class_Class.range == range(7, 45)
+        assert class_Class.range == range(7, 44)
         assert len(class_Class.children) == 9
 
         Class_class_var = class_Class.children[0]
         assert Class_class_var.name == "class_var"
         assert Class_class_var.start_line == 12
         assert Class_class_var.end_line == 12
-        assert Class_class_var.range == range(12, 13)
+        assert Class_class_var.range == range(12, 12)
 
         Class_class_var2 = class_Class.children[1]
         assert Class_class_var2.name == "class_var2"
         assert Class_class_var2.start_line == 13
         assert Class_class_var2.end_line == 13
-        assert Class_class_var2.range == range(13, 14)
+        assert Class_class_var2.range == range(13, 13)
 
         Class_class_var_with_docstring = class_Class.children[2]
         assert Class_class_var_with_docstring.name == "class_var_with_docstring"
         assert Class_class_var_with_docstring.start_line == 14
         assert Class_class_var_with_docstring.end_line == 17
-        assert Class_class_var_with_docstring.range == range(14, 18)
+        assert Class_class_var_with_docstring.range == range(14, 17)
 
         Class_static_meth = class_Class.children[3]
         assert Class_static_meth.name == "static_meth"
         assert Class_static_meth.start_line == 19
         assert Class_static_meth.end_line == 23
-        assert Class_static_meth.range == range(19, 24)
+        assert Class_static_meth.range == range(19, 23)
 
         Class_class_meth = class_Class.children[4]
         assert Class_class_meth.name == "class_meth"
         assert Class_class_meth.start_line == 25
         assert Class_class_meth.end_line == 29
-        assert Class_class_meth.range == range(25, 30)
+        assert Class_class_meth.range == range(25, 39)
 
         Class_instance_meth = class_Class.children[5]
         assert Class_instance_meth.name == "instance_meth"
         assert Class_instance_meth.start_line == 31
         assert Class_instance_meth.end_line == 34
-        assert Class_instance_meth.range == range(31, 35)
+        assert Class_instance_meth.range == range(31, 34)
 
         Class_overloaded_meth1 = class_Class.children[6]
         assert Class_overloaded_meth1.name == "overloaded_meth"
         assert Class_overloaded_meth1.start_line == 36
         assert Class_overloaded_meth1.end_line == 37
-        assert Class_overloaded_meth1.range == range(36, 38)
+        assert Class_overloaded_meth1.range == range(36, 37)
 
         Class_overloaded_meth2 = class_Class.children[7]
         assert Class_overloaded_meth2.name == "overloaded_meth"
         assert Class_overloaded_meth2.start_line == 38
         assert Class_overloaded_meth2.end_line == 39
-        assert Class_overloaded_meth2.range == range(38, 40)
+        assert Class_overloaded_meth2.range == range(38, 39)
 
         Class_overloaded_meth3 = class_Class.children[8]
         assert Class_overloaded_meth3.name == "overloaded_meth"
         assert Class_overloaded_meth3.start_line == 40
         assert Class_overloaded_meth3.end_line == 44
-        assert Class_overloaded_meth3.range == range(40, 45)
+        assert Class_overloaded_meth3.range == range(40, 44)
 
         func = node.children[1]
         assert func.name == "func"
         assert func.start_line == 46
         assert func.end_line == 49
-        assert func.range == range(46, 50)
+        assert func.range == range(46, 49)
 
         overloaded_func1 = node.children[2]
         assert overloaded_func1.name == "overloaded_func"
         assert overloaded_func1.start_line == 51
         assert overloaded_func1.end_line == 52
-        assert overloaded_func1.range == range(51, 53)
+        assert overloaded_func1.range == range(51, 52)
 
         overloaded_func2 = node.children[3]
         assert overloaded_func2.name == "overloaded_func"
         assert overloaded_func2.start_line == 53
         assert overloaded_func2.end_line == 54
-        assert overloaded_func2.range == range(53, 55)
+        assert overloaded_func2.range == range(53, 54)
 
         overloaded_func3 = node.children[4]
         assert overloaded_func3.name == "overloaded_func"
         assert overloaded_func3.start_line == 55
         assert overloaded_func3.end_line == 59
-        assert overloaded_func3.range == range(55, 60)
+        assert overloaded_func3.range == range(55, 59)


### PR DESCRIPTION
I added a note to ``DynBlockReferenceProperty.setValue``

```py
  """
  **Note**:
  No error is raised if the specified property value could not be set. For example, if the
  property has a list of allowable values or a minimum-maximum range and the value provided
  is not in the list or is out of range, the method succeeds and no error is raised.
  """
```

 and corrected a bug I found in pyi_gen